### PR TITLE
Python 3 compatibility

### DIFF
--- a/epub_search/__main__.py
+++ b/epub_search/__main__.py
@@ -30,10 +30,13 @@ except ImportError:
     curses = None
 
 try:
-    import cStringIO as StringIO
+    try:
+        import cStringIO as StringIO
 
+    except ImportError:
+        import StringIO
 except ImportError:
-    import StringIO
+    from io import StringIO # Python 3
 
 from epub_search import matching
 from epub_search import search
@@ -168,7 +171,12 @@ def _epub_search(argv):
 
         # Redirect until after after search
         saved_stderr = sys.stderr
-        sys.stderr = StringIO.StringIO()
+        
+        # Python 3 compat
+        try:
+            sys.stderr = StringIO.StringIO()
+        except:
+            sys.stderr = StringIO()
 
         curses_window = curses.initscr()
 

--- a/epub_search/epub.py
+++ b/epub_search/epub.py
@@ -28,6 +28,18 @@ from lxml import etree as ElementTree
 
 from epub_search.tag_stripper import TagStripError, TagStripper
 
+# Python 3 compat
+try:
+    range = xrange
+except:
+    pass
+
+try:
+    unquote = urllib.unquote
+except:
+    import urllib.parse
+    unquote = urllib.parse.unquote
+
 
 _Item = namedtuple('_Item', ('path', 'media_type'))
 
@@ -221,7 +233,7 @@ class Epub(object):
             # in case the author role was not found
             self.__author = creators[0].text.strip()
 
-            for i in xrange(1, len(creators)):
+            for i in range(1, len(creators)):
                 if _XPATH_CREATOR_IS_AUTHOR(creators[i]):
                     self.__author = creators[i].text.strip()
                     break
@@ -239,7 +251,7 @@ class Epub(object):
             item_href = item.get('href')
             item_media_type = item.get('media-type')
 
-            manifest[item_id] = _Item(path=urllib.unquote(item_href),
+            manifest[item_id] = _Item(path=unquote(item_href),
                                       media_type=item_media_type)
 
         return manifest
@@ -261,7 +273,7 @@ class Epub(object):
             if text is None or src is None:
                 continue
 
-            item_labels[urllib.unquote(src)] = text.strip()
+            item_labels[unquote(src)] = text.strip()
 
         return item_labels
 

--- a/epub_search/matching.py
+++ b/epub_search/matching.py
@@ -19,6 +19,12 @@
 
 import re
 
+# Python 3 compat
+try:
+    basestring = basestring
+except NameError:
+    basestring = (str,bytes)
+
 
 class Match(object):
     __slots__ = ('text', 'match_positions')

--- a/epub_search/tag_stripper.py
+++ b/epub_search/tag_stripper.py
@@ -84,7 +84,10 @@ else:
             self.__parser.buffer_text = True
 
             # Faster to parse str than unicode
-            self.__parser.returns_unicode = False
+            try:
+                self.__parser.returns_unicode = False
+            except: 
+                pass # Python 3
 
         def parse(self, xhtml):
             try:
@@ -165,7 +168,7 @@ class TagStripper(object):
     def __call__(self, xhtml):
         while 1:
             try:
-                return self.__tag_stipper(xhtml.replace('\n', ' '))
+                return self.__tag_stipper(xhtml.replace(b'\n', b' '))
 
             except TagStripError:
                 if not self.__tag_stippers:

--- a/epub_search/util.py
+++ b/epub_search/util.py
@@ -51,7 +51,12 @@ def unique(iterable):
     seen = set()
     seen_add = seen.add
 
-    for element in itertools.ifilterfalse(seen.__contains__, iterable):
+    # Python 3 compat
+    try:
+        ifilterfalse = itertools.ifilterfalse
+    except:
+        ifilterfalse = itertools.filterfalse
+    for element in ifilterfalse(seen.__contains__, iterable):
         seen_add(element)
 
         yield element

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@ import sys
 from setuptools import setup
 
 import epub_search
-from setup.enviroment import extensions
-from setup.failablebuildext import BuildFailed, FailableBuildExt
+sys.path.insert(0, './setup')
+from enviroment import extensions
+from failablebuildext import BuildFailed, FailableBuildExt
 
 
 if sys.version_info < (2, 7, 0):


### PR DESCRIPTION
Not sure if I got every edge case, since there's no test suite, but at least both `setup.py install`, and a simple `epub-search "~/Downloads/" Ostfriesen` work, and give identical results with Python 2 and 3.